### PR TITLE
fixing warnings/lint

### DIFF
--- a/example/lib/demo.dart
+++ b/example/lib/demo.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -61,7 +60,7 @@ class TestFpsState extends State<TestFpsWidget> {
             top: 10,
             child: Text(
               "fps:$_currentFps",
-              style: TextStyle(color: Colors.red,fontSize: 20),
+              style: TextStyle(color: Colors.red, fontSize: 20),
             ))
       ],
     );

--- a/lib/binding_fps.dart
+++ b/lib/binding_fps.dart
@@ -71,11 +71,11 @@ class BindingFps {
 
   /// 注册回调
   registerCallBack(FpsCallback back) {
-    _callBackList?.add(back);
+    _callBackList.add(back);
   }
 
   unregisterCallBack(FpsCallback back) {
-    _callBackList?.remove(back);
+    _callBackList.remove(back);
   }
 
   /// 当前帧
@@ -150,13 +150,13 @@ class BindingFps {
 
     var _calFrameQueue = ListQueue(_frameQueue.length);
     _calFrameQueue.addAll(_frameQueue);
-    _frameQueue?.clear();
+    _frameQueue.clear();
     while (_calFrameQueue.length > _fpsHz!) {
       _calFrameQueue.removeLast();
     }
-    double drawFrame = _calFrameQueue?.length?.toDouble() ?? 0;
+    double drawFrame = _calFrameQueue.length.toDouble();
     double dropFrameCount = _fpsHz! - drawFrame;
-    _callBackList?.forEach((callBack) {
+    _callBackList.forEach((callBack) {
       callBack(drawFrame.toDouble(), dropFrameCount.toDouble());
     });
 //    DebugLog.instance.log(


### PR DESCRIPTION
Fixes some null-safety warnings and a lint message generated using flutter 2.10.5 & dart 2.16.2.  There are others using a more modern version of flutter/dart, but keeping the changeset smaller for now.

### Before
```
warning: The receiver can't be null, so the null-aware operator '?.' is unnecessary. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:74)
warning: The receiver can't be null, so the null-aware operator '?.' is unnecessary. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:78)
warning: The receiver can't be null, so the null-aware operator '?.' is unnecessary. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:153)
warning: The receiver can't be null, so the null-aware operator '?.' is unnecessary. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:157)
warning: The receiver can't be null because of short-circuiting, so the null-aware operator '?.' can't be used. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:157)
warning: The receiver can't be null, so the null-aware operator '?.' is unnecessary. (invalid_null_aware_operator at [performance_fps] lib\binding_fps.dart:159)
info: The import of 'package:flutter/cupertino.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'. (unnecessary_import at [fps_example] lib\demo.dart:1)
```